### PR TITLE
Fixes/updates to deployment tooling

### DIFF
--- a/Solutions/InstanceManifests/Stable.json
+++ b/Solutions/InstanceManifests/Stable.json
@@ -4,7 +4,7 @@
       "release": "0.3.0-preview.36"
     },
     "Marain.Operations": {
-      "release": "0.9.0-preview-44"
+      "release": "0.9.0-preview.44"
     },
     "Marain.Workflow": {
       "release": "0.2.0-preview.80"

--- a/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
+++ b/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
@@ -868,7 +868,7 @@ try {
 
         if ((-not $SingleServiceToDeploy) -or ($SingleServiceToDeploy -eq $MarainServiceName)) {
             $ServiceManifestEntry = $InstanceManifest.services.$MarainServiceName
-            if ($null -ne $ServiceManifestEntry.omit -and $ServiceManifestEntry.omit) {
+            if ( ($ServiceManifestEntry | Get-Member omit) -and $ServiceManifestEntry.omit) {
                 continue
             }
             Write-Host "Starting infrastructure deployment for $MarainServiceName"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ variables:
   Endjin_SubscriptionId: 13821a69-41a3-43ab-9577-1519963ea474
   Endjin_AzureServiceConnection: marjd-ado-spn
   Endjin_EnvironmentSuffix: jd
-  Marain_Instance_Type: Development
+  Marain_Instance_Type: Stable
   Marain_ResourcePrefix: marain
 
 

--- a/azurepipeline-templates/deploy-marain-instance.yml
+++ b/azurepipeline-templates/deploy-marain-instance.yml
@@ -4,7 +4,8 @@ parameters:
   azureTenantId:
   azureLocation:
   marainEnvironmentSuffix:
-  marainInstanceType:
+  marainManifestPath: "../InstanceManifests"
+  marainReleaseChannel:
   marainResourcePrefix:
   workingDirectory:
     
@@ -34,7 +35,7 @@ steps:
             -EnvironmentSuffix ${{ parameters.marainEnvironmentSuffix }} `
             -AadTenantId ${{ parameters.azureTenantId }} `
             -SubscriptionId ${{ parameters.azureSubscriptionId }} `
-            -InstanceManifest ../InstanceManifests/${{ parameters.marainInstanceType }}.json `
+            -InstanceManifest ${{ parameters.marainManifestPath }}/${{ parameters.marainInstanceType }}.json `
             -Prefix ${{ parameters.marainResourcePrefix }}
     azurePowerShellVersion: latestVersion
     pwsh: true


### PR DESCRIPTION
- Fixes some issues with how the 'Stable' release channel was setup
- Changes the CI process to test the 'Stable' channel, rather than the 'Development' channel
- Extends ADO step template to support using a different instance manifest, rather than the one included in this repo (i.e. 'bring-your-own' instance manifest)