### PR TITLE
Add user notifications

### DIFF
--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -9,11 +9,11 @@
       "release": "1.0.0"
     },
     "Marain.Workflow": {
-      "omit": true,
+      "omit": false,
       "release": "0.2.0"
     },
     "Marain.Claims": {
-      "omit": true,
+      "omit": false,
       "release": "1.2.0"
     },
     "Marain.UserNotifications": {

--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -2,19 +2,23 @@
   "services": {
     "Marain.Tenancy": {
       "omit": false,
-      "release": "0.3.0-preview.36"
+      "release": "1.0.1"
     },
     "Marain.Operations": {
       "omit": false,
-      "release": "0.9.0-preview.44"
+      "release": "1.0.0"
     },
     "Marain.Workflow": {
-      "omit": false,
-      "release": "0.2.0-preview.86"
+      "omit": true,
+      "release": "0.2.0"
     },
     "Marain.Claims": {
-      "omit": false,
+      "omit": true,
       "release": "1.2.0"
+    },
+    "Marain.UserNotifications": {
+      "omit": false,
+      "release": "0.1.0"
     }
   }
 }

--- a/Solutions/InstanceManifests/Stable.json
+++ b/Solutions/InstanceManifests/Stable.json
@@ -1,16 +1,20 @@
 {
   "services": {
     "Marain.Tenancy": {
-      "release": "0.3.0-preview.36"
+      "release": "1.0.1"
     },
     "Marain.Operations": {
-      "release": "0.9.0-preview.44"
+      "release": "1.0.0"
     },
     "Marain.Workflow": {
-      "release": "0.2.0-preview.83"
+      "release": "0.2.0"
     },
     "Marain.Claims": {
       "release": "1.2.0"
+    },
+    "Marain.UserNotifications": {
+      "omit": true,
+      "release": "0.1.0"
     }
   }
 }

--- a/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
+++ b/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
@@ -21,7 +21,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 4
 
 $marainGlobalToolName = 'marain'
-$marainGlobalToolVersion = '0.1.0-cli-as-global-tool.21'
+$marainGlobalToolVersion = '1.1.2'
 
 class MarainInstanceDeploymentContext {
     MarainInstanceDeploymentContext(

--- a/Solutions/MarainServices.jsonc
+++ b/Solutions/MarainServices.jsonc
@@ -20,5 +20,9 @@
     "Marain.Claims": {
         "gitHubProject": "marain-dotnet/Marain.Claims",
         "apiPrefix": "claims"
+    },
+    "Marain.UserNotifications": {
+        "gitHubProject": "marain-dotnet/Marain.UserNotifications",
+        "apiPrefix": "notifications"
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,12 @@ stages:
                 gci variable:\ | ft -AutoSize | Out-String | Write-Host
                 Write-Host "*** Module info:"
                 Get-Module -ListAvailable | Select Name,Version,Path
-              azurePowerShellVersion: latestVersion
+              # Temporarily force a downgrade of the AzurePowerShell cmdlets because (as of September 2020 and v4.6.0) a bug
+              # was introduced which breaks use of securestring with ARM templates:
+              # https://github.com/Azure/azure-powershell/issues/12792
+              # https://github.com/Azure/azure-powershell/issues/12819
+              # Once this issue is fixed, we should revert back to using the latest version of the cmdlets.
+              preferredAzurePowerShellVersion: '4.4.0'
               pwsh: true
 
           - template: azurepipeline-templates/deploy-marain-instance.yml
@@ -130,5 +135,10 @@ stages:
               Write-Host ("Checking AzureAD application: {0}" -f $appName)
               Get-AzADApplication -DisplayName $appName | Select -First 1 | Remove-AzADApplication -Verbose -Force
           }
-        azurePowerShellVersion: latestVersion
+        # Temporarily force a downgrade of the AzurePowerShell cmdlets because (as of September 2020 and v4.6.0) a bug
+        # was introduced which breaks use of securestring with ARM templates:
+        # https://github.com/Azure/azure-powershell/issues/12792
+        # https://github.com/Azure/azure-powershell/issues/12819
+        # Once this issue is fixed, we should revert back to using the latest version of the cmdlets.
+        preferredAzurePowerShellVersion: '4.4.0'
         pwsh: true

--- a/azurepipeline-templates/deploy-marain-instance.yml
+++ b/azurepipeline-templates/deploy-marain-instance.yml
@@ -37,6 +37,11 @@ steps:
             -SubscriptionId ${{ parameters.azureSubscriptionId }} `
             -InstanceManifest ${{ parameters.marainManifestPath }}/${{ parameters.marainInstanceType }}.json `
             -Prefix ${{ parameters.marainResourcePrefix }}
-    azurePowerShellVersion: latestVersion
+    # Temporarily force a downgrade of the AzurePowerShell cmdlets because (as of September 2020 and v4.6.0) a bug
+    # was introduced which breaks use of securestring with ARM templates:
+    # https://github.com/Azure/azure-powershell/issues/12792
+    # https://github.com/Azure/azure-powershell/issues/12819
+    # Once this issue is fixed, we should revert back to using the latest version of the cmdlets.
+    preferredAzurePowerShellVersion: '4.4.0'
     pwsh: true
     workingDirectory: ${{ parameters.workingDirectory }}


### PR DESCRIPTION
Adds the new user notifications service. This also requires an update to the version of the `marain` tool being used, as the currently referenced version does not support table storage configuration.