### PR TITLE
Shorten the name of the notifications service

### DIFF
--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -18,7 +18,7 @@
     },
     "Marain.UserNotifications": {
       "omit": false,
-      "release": "0.1.1"
+      "release": "0.1.2"
     }
   }
 }

--- a/Solutions/Marain.Instance.Deployment/quick-teardown.ps1
+++ b/Solutions/Marain.Instance.Deployment/quick-teardown.ps1
@@ -14,7 +14,9 @@ $groups = @(
     "tenancy"
     "operations"
     "workflow"
-    "instance"
+    "instance",
+    "claims",
+    "notifications"
 )
 $jobs = @()
 foreach ($g in $groups) {
@@ -34,7 +36,10 @@ $aadApps = @(
     "operationscontrol"
     "workfloweng"
     "workflowmi"
+    "claims"
     "tenantadmin"
+    "usrnotidel"
+    "usrnotimng"
 )
 foreach ($a in $aadApps) {
     $app = "{0}{1}{2}" -f $Prefix,  $EnvironmentSuffix, $a

--- a/Solutions/MarainServices.jsonc
+++ b/Solutions/MarainServices.jsonc
@@ -23,6 +23,6 @@
     },
     "Marain.UserNotifications": {
         "gitHubProject": "marain-dotnet/Marain.UserNotifications",
-        "apiPrefix": "notifications"
+        "apiPrefix": "usrnoti"
     }
 }


### PR DESCRIPTION
Brings the Marain.Instance deployment in line with the shortened name of Marain UserNotifications once https://github.com/marain-dotnet/Marain.UserNotifications/pull/56 has been merged back and a new release created.