### PR TITLE
Update Azure CLI error handling

### DIFF
--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -6,11 +6,11 @@
     },
     "Marain.Operations": {
       "omit": false,
-      "release": "1.2.2"
+      "release": "1.2.4"
     },
     "Marain.Workflow": {
       "omit": false,
-      "release": "0.2.8"
+      "release": "0.2.9"
     },
     "Marain.Claims": {
       "omit": false,

--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -14,11 +14,11 @@
     },
     "Marain.Claims": {
       "omit": false,
-      "release": "3.1.0"
+      "release": "3.1.1"
     },
     "Marain.UserNotifications": {
       "omit": false,
-      "release": "0.3.8"
+      "release": "0.3.9"
     }
   }
 }

--- a/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
+++ b/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
@@ -47,7 +47,7 @@ function Invoke-AzCli
     $azCliErrorLog = New-TemporaryFile
     try {
 
-        $res = Invoke-Expression $CommandLine 2> $($azCliErrorLog.FullName)
+        $res = Invoke-Expression $cmd 2> $($azCliErrorLog.FullName)
         $azCliStdErr = Get-Content -Raw $azCliErrorLog
     }
     finally {

--- a/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
+++ b/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
@@ -42,8 +42,17 @@ function Invoke-AzCli
     if ($asJson) { $cmd = "$cmd -o json" }
     Write-Verbose "azcli cmd: $cmd"
     
-    $ErrorActionPreference = 'Continue'     # azure-cli can sometimes write warnings to STDERR, which PowerShell treats as an error
-    $res = Invoke-Expression "$cmd 2>''" -ErrorVariable azCliStdErr
+    # PowerShell 7.2.0 introduced a bug when using -ErrorVariable to capture errors, so we
+    # have fallen back to using file-based redirection
+    $azCliErrorLog = New-TemporaryFile
+    try {
+
+        $res = Invoke-Expression $CommandLine 2> $($azCliErrorLog.FullName)
+        $azCliStdErr = Get-Content -Raw $azCliErrorLog
+    }
+    finally {
+        Remove-Item -Path $azCliErrorLog -Force
+    }
     
     $diagnosticInfo = @"
 StdOut:
@@ -51,7 +60,6 @@ $res
 StdErr:
 $azCliStdErr
 "@
-    $ErrorActionPreference = 'Stop'
     if ($expectedExitCodes -inotcontains $LASTEXITCODE) {
         Write-Error "azure-cli failed with exit code: $LASTEXITCODE`nDiagnostic information follows:`nCommand: $cmd`n$diagnosticInfo"
     }


### PR DESCRIPTION
This works around a behaviour change/bug in PowerShell 7.2.0 where '-ErrorVariable' does not capture messages sent to standard error stream.