### PR TITLE
Fix deployment issue caused by breaking changes in AAD

### DIFF
--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -2,7 +2,7 @@
   "services": {
     "Marain.Tenancy": {
       "omit": false,
-      "release": "2.0.6-deployfix.1"
+      "release": "2.0.6-deployfix.2"
     },
     "Marain.Operations": {
       "omit": false,

--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -2,7 +2,7 @@
   "services": {
     "Marain.Tenancy": {
       "omit": false,
-      "release": "1.1.14"
+      "release": "2.0.6-deployfix.1"
     },
     "Marain.Operations": {
       "omit": false,

--- a/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
+++ b/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
@@ -403,6 +403,7 @@ class MarainServiceDeploymentContext {
         } else {
             $app = New-AzADApplication -DisplayName $DisplayName -HomePage $appUri -ReplyUrls $replyUrls
             Write-Host "Created new app with id $($app.$appIdPropertyName)"
+            $app | Update-AzADApplication -IdentifierUri "api://$($app.$appIdPropertyName)"
         }
 
         return [AzureAdAppWithGraphAccess]::new($this, $app.$appIdPropertyName, $app.$objectIdPropertyName)

--- a/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
+++ b/Solutions/Marain.Instance.Deployment/Deploy-MarainInstanceInfrastructure.ps1
@@ -396,7 +396,7 @@ class MarainServiceDeploymentContext {
                 $app = Update-AzADApplication -ObjectId $app.ObjectId -ReplyUrl $replyUrls
             }
         } else {
-            $app = New-AzADApplication -DisplayName $DisplayName -IdentifierUris $appUri -HomePage $appUri -ReplyUrls $replyUrls
+            $app = New-AzADApplication -DisplayName $DisplayName -HomePage $appUri -ReplyUrls $replyUrls
             Write-Host "Created new app with id $($app.ApplicationId)"
         }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ variables:
   Endjin_SubscriptionId: 98333d29-7302-4f93-a51d-70c49ca7e180
   Endjin_AzureServiceConnection: endjin-internal-development
   Endjin_EnvironmentSuffix: td
-  Marain_Instance_Type: Stable
+  Marain_Instance_Type: Development
   Marain_ResourcePrefix: mar
 
 


### PR DESCRIPTION
Also adds handling for the breaking changes resulting from Azure PowerShell's migration to using Microsoft Graph.  This aims to make the deployment scripts work with both flavours.

References:
* https://docs.microsoft.com/en-gb/azure/active-directory/develop/reference-breaking-changes#appid-uri-in-single-tenant-applications-will-require-use-of-default-scheme-or-verified-domains
* https://docs.microsoft.com/en-us/powershell/azure/azps-msgraph-migration-changes