### PR TITLE
Update Marain component versions

### DIFF
--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -2,23 +2,23 @@
   "services": {
     "Marain.Tenancy": {
       "omit": false,
-      "release": "3.0.5-storage-https-only.3"
+      "release": "3.0.5"
     },
     "Marain.Operations": {
       "omit": false,
-      "release": "3.0.2-storage-https-only.6"
+      "release": "3.0.2"
     },
     "Marain.Workflow": {
       "omit": false,
-      "release": "0.4.3-storage-https-only.1"
+      "release": "0.4.3"
     },
     "Marain.Claims": {
       "omit": false,
-      "release": "5.1.2-storage-https-only.2"
+      "release": "5.1.2"
     },
     "Marain.UserNotifications": {
       "omit": false,
-      "release": "0.4.1-storage-https-only.5"
+      "release": "0.4.1"
     }
   },
   "tools": {

--- a/Solutions/InstanceManifests/Development.json
+++ b/Solutions/InstanceManifests/Development.json
@@ -2,23 +2,23 @@
   "services": {
     "Marain.Tenancy": {
       "omit": false,
-      "release": "3.0.3"
+      "release": "3.0.5-storage-https-only.3"
     },
     "Marain.Operations": {
       "omit": false,
-      "release": "3.0.1"
+      "release": "3.0.2-storage-https-only.6"
     },
     "Marain.Workflow": {
       "omit": false,
-      "release": "0.4.1"
+      "release": "0.4.3-storage-https-only.1"
     },
     "Marain.Claims": {
       "omit": false,
-      "release": "5.1.0"
+      "release": "5.1.2-storage-https-only.2"
     },
     "Marain.UserNotifications": {
       "omit": false,
-      "release": "0.4.0"
+      "release": "0.4.1-storage-https-only.5"
     }
   },
   "tools": {

--- a/Solutions/InstanceManifests/Stable.json
+++ b/Solutions/InstanceManifests/Stable.json
@@ -2,23 +2,23 @@
   "services": {
     "Marain.Tenancy": {
       "omit": false,
-      "release": "3.0.3"
+      "release": "3.0.5"
     },
     "Marain.Operations": {
       "omit": false,
-      "release": "3.0.1"
+      "release": "3.0.2"
     },
     "Marain.Workflow": {
       "omit": false,
-      "release": "0.4.1"
+      "release": "0.4.3"
     },
     "Marain.Claims": {
       "omit": false,
-      "release": "5.1.0"
+      "release": "5.1.2"
     },
     "Marain.UserNotifications": {
       "omit": false,
-      "release": "0.4.0"
+      "release": "0.4.1"
     }
   },
   "tools": {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,8 +121,8 @@ stages:
               Get-AzResourceGroup $groupName -ErrorAction SilentlyContinue | Select -First 1 | Remove-AzResourceGroup -Verbose -Force
             }
           @("tenancy","operationscontrol","workfloweng","workflowmi","tenantadmin","claims","usrnotidel","usrnotimng") |
-            ForEach-Object -Parallel {
-              $appName = "{0}{1}{2}" -f $using:prefix, $using:suffix, $_
+            ForEach-Object {
+              $appName = "{0}{1}{2}" -f $prefix, $suffix, $_
               Write-Host ("Checking AzureAD application: {0}" -f $appName)
               Get-AzADApplication -DisplayName $appName | Select -First 1 | Remove-AzADApplication -Verbose
             }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,12 @@ stages:
         azureSubscription: '$(Endjin_AzureServiceConnection)'
         ScriptType: InlineScript
         Inline: |
+          trap {
+            Write-Host -f Red $_.Exception.Message
+            Write-Host -f Yellow $_.InvocationInfo.PositionMessage
+            Write-Host -f Yellow $_.ScriptStackTrace
+          }
+
           $prefix = "$(Marain_ResourcePrefix)"
           $suffix = "$(Endjin_EnvironmentSuffix)"
           @("claims","notifications","workflow","operations","tenancy","instance") |


### PR DESCRIPTION
* Bumps the manifest versions to include the recent changes that enforce HTTPS-only access to storage accounts
* Update to improve robustness of deployment smoke test infrastructure cleardown